### PR TITLE
Fixing import issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "axios": "^1.4.0",
-        "music-metadata": "^8.1.4",
+        "music-metadata": "^7.13.4",
         "qs": "^6.11.2",
         "uuid": "^9.0.0"
       },
@@ -4626,16 +4626,16 @@
       }
     },
     "node_modules/file-type": {
-      "version": "18.5.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-18.5.0.tgz",
-      "integrity": "sha512-yvpl5U868+V6PqXHMmsESpg6unQ5GfnPssl4dxdJudBrr9qy7Fddt7EVX1VLlddFfe8Gj9N7goCZH22FXuSQXQ==",
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
+      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
       "dependencies": {
-        "readable-web-to-node-stream": "^3.0.2",
-        "strtok3": "^7.0.0",
-        "token-types": "^5.0.1"
+        "readable-web-to-node-stream": "^3.0.0",
+        "strtok3": "^6.2.4",
+        "token-types": "^4.1.1"
       },
       "engines": {
-        "node": ">=14.16"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
@@ -7854,20 +7854,20 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/music-metadata": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-8.1.4.tgz",
-      "integrity": "sha512-q9mw2qeESeJY69cXtdaum/YJstDimpP+mwZnb801iq20JpyY75v6uzcp6VfVXZDixpD2f9yWneJtA0TgSEypxA==",
+      "version": "7.13.4",
+      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-7.13.4.tgz",
+      "integrity": "sha512-eRRoEMhhYdth2Ws24FmkvIqrtkIBE9sqjHbrRNpkg2Iux3zc37PQKRv2/r/mTtELb7XlB1uWC2UcKKX7BzNMGA==",
       "dependencies": {
         "@tokenizer/token": "^0.3.0",
         "content-type": "^1.0.5",
         "debug": "^4.3.4",
-        "file-type": "^18.2.1",
+        "file-type": "^16.5.4",
         "media-typer": "^1.1.0",
-        "strtok3": "^7.0.0",
-        "token-types": "^5.0.1"
+        "strtok3": "^6.3.0",
+        "token-types": "^4.2.1"
       },
       "engines": {
-        "node": "^14.13.1 || >=16.0.0"
+        "node": ">=10"
       },
       "funding": {
         "type": "github",
@@ -11284,11 +11284,11 @@
       }
     },
     "node_modules/peek-readable": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-5.0.0.tgz",
-      "integrity": "sha512-YtCKvLUOvwtMGmrniQPdO7MwPjgkFBtFIrmfSbYmYuq3tKDV/mcfAhBth1+C3ru7uXIZasc/pHnb+YDYNkkj4A==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
+      "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==",
       "engines": {
-        "node": ">=14.16"
+        "node": ">=8"
       },
       "funding": {
         "type": "github",
@@ -12837,15 +12837,15 @@
       }
     },
     "node_modules/strtok3": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-7.0.0.tgz",
-      "integrity": "sha512-pQ+V+nYQdC5H3Q7qBZAz/MO6lwGhoC2gOAjuouGf/VO0m7vQRh8QNMl2Uf6SwAtzZ9bOw3UIeBukEGNJl5dtXQ==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
+      "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
       "dependencies": {
         "@tokenizer/token": "^0.3.0",
-        "peek-readable": "^5.0.0"
+        "peek-readable": "^4.1.0"
       },
       "engines": {
-        "node": ">=14.16"
+        "node": ">=10"
       },
       "funding": {
         "type": "github",
@@ -13079,15 +13079,15 @@
       }
     },
     "node_modules/token-types": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/token-types/-/token-types-5.0.1.tgz",
-      "integrity": "sha512-Y2fmSnZjQdDb9W4w4r1tswlMHylzWIeOKpx0aZH9BgGtACHhrk3OkT52AzwcuqTRBZtvvnTjDBh8eynMulu8Vg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
+      "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
       "dependencies": {
         "@tokenizer/token": "^0.3.0",
         "ieee754": "^1.2.1"
       },
       "engines": {
-        "node": ">=14.16"
+        "node": ">=10"
       },
       "funding": {
         "type": "github",
@@ -17200,13 +17200,13 @@
       }
     },
     "file-type": {
-      "version": "18.5.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-18.5.0.tgz",
-      "integrity": "sha512-yvpl5U868+V6PqXHMmsESpg6unQ5GfnPssl4dxdJudBrr9qy7Fddt7EVX1VLlddFfe8Gj9N7goCZH22FXuSQXQ==",
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
+      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
       "requires": {
-        "readable-web-to-node-stream": "^3.0.2",
-        "strtok3": "^7.0.0",
-        "token-types": "^5.0.1"
+        "readable-web-to-node-stream": "^3.0.0",
+        "strtok3": "^6.2.4",
+        "token-types": "^4.1.1"
       }
     },
     "fill-range": {
@@ -19717,17 +19717,17 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "music-metadata": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-8.1.4.tgz",
-      "integrity": "sha512-q9mw2qeESeJY69cXtdaum/YJstDimpP+mwZnb801iq20JpyY75v6uzcp6VfVXZDixpD2f9yWneJtA0TgSEypxA==",
+      "version": "7.13.4",
+      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-7.13.4.tgz",
+      "integrity": "sha512-eRRoEMhhYdth2Ws24FmkvIqrtkIBE9sqjHbrRNpkg2Iux3zc37PQKRv2/r/mTtELb7XlB1uWC2UcKKX7BzNMGA==",
       "requires": {
         "@tokenizer/token": "^0.3.0",
         "content-type": "^1.0.5",
         "debug": "^4.3.4",
-        "file-type": "^18.2.1",
+        "file-type": "^16.5.4",
         "media-typer": "^1.1.0",
-        "strtok3": "^7.0.0",
-        "token-types": "^5.0.1"
+        "strtok3": "^6.3.0",
+        "token-types": "^4.2.1"
       }
     },
     "mute-stream": {
@@ -22084,9 +22084,9 @@
       "dev": true
     },
     "peek-readable": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-5.0.0.tgz",
-      "integrity": "sha512-YtCKvLUOvwtMGmrniQPdO7MwPjgkFBtFIrmfSbYmYuq3tKDV/mcfAhBth1+C3ru7uXIZasc/pHnb+YDYNkkj4A=="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
+      "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg=="
     },
     "picomatch": {
       "version": "2.3.1",
@@ -23197,12 +23197,12 @@
       "dev": true
     },
     "strtok3": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-7.0.0.tgz",
-      "integrity": "sha512-pQ+V+nYQdC5H3Q7qBZAz/MO6lwGhoC2gOAjuouGf/VO0m7vQRh8QNMl2Uf6SwAtzZ9bOw3UIeBukEGNJl5dtXQ==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
+      "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
       "requires": {
         "@tokenizer/token": "^0.3.0",
-        "peek-readable": "^5.0.0"
+        "peek-readable": "^4.1.0"
       }
     },
     "supports-color": {
@@ -23381,9 +23381,9 @@
       }
     },
     "token-types": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/token-types/-/token-types-5.0.1.tgz",
-      "integrity": "sha512-Y2fmSnZjQdDb9W4w4r1tswlMHylzWIeOKpx0aZH9BgGtACHhrk3OkT52AzwcuqTRBZtvvnTjDBh8eynMulu8Vg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
+      "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
       "requires": {
         "@tokenizer/token": "^0.3.0",
         "ieee754": "^1.2.1"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sber-salute-speech-recognition",
-  "version": "0.1.0",
-  "description": "A library for getting audio transcriptions from the SBER Salute Speech service",
+  "version": "1.0.1",
+  "description": "A library that produces audio transcriptions using the SBER Salute Speech service.",
   "main": "./lib/index.js",
   "files": [
     "lib/**/*"
@@ -120,7 +120,7 @@
   },
   "dependencies": {
     "axios": "^1.4.0",
-    "music-metadata": "^8.1.4",
+    "music-metadata": "^7.13.4",
     "qs": "^6.11.2",
     "uuid": "^9.0.0"
   }

--- a/src/sberSaluteSpeechRecognitionService.ts
+++ b/src/sberSaluteSpeechRecognitionService.ts
@@ -2,6 +2,7 @@ import { Agent } from 'https';
 import { IAudioMetadata, parseFile } from 'music-metadata';
 import axios from 'axios';
 import * as qs from 'qs';
+import * as fs from 'fs';
 import {
   MAX_WAIT_TIME,
   RECOGNITION_POLLING_DELAY,
@@ -77,6 +78,7 @@ export class SberSaluteSpeechRecognitionService
     audioFilePath: string
   ): Promise<FileUploadResponse> {
     const { access_token } = await this.getAccessToken();
+    const audioFile = fs.createReadStream(audioFilePath);
     const response = await axios.request({
       method: 'post',
       maxBodyLength: Infinity,
@@ -85,7 +87,7 @@ export class SberSaluteSpeechRecognitionService
         Authorization: `Bearer ${access_token}`,
         'Content-Type': 'audio/mpeg',
       },
-      data: audioFilePath,
+      data: audioFile,
       httpsAgent: new Agent({
         rejectUnauthorized: false,
       }),
@@ -199,6 +201,7 @@ export class SberSaluteSpeechRecognitionService
     const recognitionResult = await this.getRecognitionResult(
       recognitionStatus
     );
+
     const text = recognitionResult
       .reduce((acc, item) => {
         return (

--- a/src/sberSaluteSpeechRecognitionService.ts
+++ b/src/sberSaluteSpeechRecognitionService.ts
@@ -1,7 +1,7 @@
 import { Agent } from 'https';
 import { IAudioMetadata, parseFile } from 'music-metadata';
 import axios from 'axios';
-import qs from 'qs';
+import * as qs from 'qs';
 import {
   MAX_WAIT_TIME,
   RECOGNITION_POLLING_DELAY,
@@ -9,7 +9,7 @@ import {
   SPEECH_TOKEN_URL,
   TOKEN_SCOPE,
 } from './constants';
-import uuid from 'uuid';
+import * as uuid from 'uuid';
 import {
   SupportedAudioEncoding,
   SpeechToTextResult,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,17 +4,17 @@
 
     /* Basic Options */
     // "incremental": true,                         /* Enable incremental compilation */
-    "target": "es6",                                /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
-    "module": "commonjs",                           /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
+    "target": "es6" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
+    "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
     // "lib": [],                                   /* Specify library files to be included in the compilation. */
     // "allowJs": true,                             /* Allow javascript files to be compiled. */
     // "checkJs": true,                             /* Report errors in .js files. */
     // "jsx": "preserve",                           /* Specify JSX code generation: 'preserve', 'react-native', 'react', 'react-jsx' or 'react-jsxdev'. */
-    "declaration": true,                            /* Generates corresponding '.d.ts' file. */
+    "declaration": true /* Generates corresponding '.d.ts' file. */,
     // "declarationMap": true,                      /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                           /* Generates corresponding '.map' file. */
     // "outFile": "./",                             /* Concatenate and emit output to single file. */
-    "outDir": "./lib/",                             /* Redirect output structure to the directory. */
+    "outDir": "./lib/" /* Redirect output structure to the directory. */,
     // "rootDir": "./",                             /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "composite": true,                           /* Enable project compilation */
     // "tsBuildInfoFile": "./",                     /* Specify file to store incremental compilation information */
@@ -25,7 +25,7 @@
     // "isolatedModules": true,                     /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
 
     /* Strict Type-Checking Options */
-    "strict": true,                                 /* Enable all strict type-checking options. */
+    "strict": true /* Enable all strict type-checking options. */,
     // "noImplicitAny": true,                       /* Raise error on expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,                    /* Enable strict null checks. */
     // "strictFunctionTypes": true,                 /* Enable strict checking of function types. */
@@ -50,7 +50,7 @@
     // "typeRoots": [],                             /* List of folders to include type definitions from. */
     // "types": [],                                 /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,        /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true,                        /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "esModuleInterop": false /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
     // "preserveSymlinks": true,                    /* Do not resolve the real path of symlinks. */
     // "allowUmdGlobalAccess": true,                /* Allow accessing UMD globals from modules. */
 
@@ -65,8 +65,8 @@
     // "emitDecoratorMetadata": true,               /* Enables experimental support for emitting type metadata for decorators. */
 
     /* Advanced Options */
-    "skipLibCheck": true,                           /* Skip type checking of declaration files. */
-    "forceConsistentCasingInFileNames": true        /* Disallow inconsistently-cased references to the same file. */
+    "skipLibCheck": true /* Skip type checking of declaration files. */,
+    "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
   },
   "include": ["src/**/*.ts", "test/**/*.ts"]
 }


### PR DESCRIPTION
### Description of change

Usage of latest music metadata broke common js import of the library.
This change downgrades the lib version and now we can support import through require.

### Pull-Request Checklist

- [x] Code is up-to-date with the `main` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)
