### PR TITLE
refactor(package): accept audio encoding as enum value

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ npm install sber-salute-speech-recognition
 ## Usage
 
 ```ts
-import { SberSaluteSpeechRecognitionService } from 'sber-salute-speech-recognition';
+import { SberSaluteSpeechRecognitionService, AudioEncoding } from 'sber-salute-speech-recognition';
 
 const recognitionService = new SberSaluteSpeechRecognitionService(AUTH_KEY);
 const { text, normalizedText } = await recognitionService.speechToText(
   pathToAudioFile,
-  'MP3'
+  AudioEncoding.MP3
 );
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sber-salute-speech-recognition",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sber-salute-speech-recognition",
-      "version": "1.0.1",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sber-salute-speech-recognition",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "A library that produces audio transcriptions using the SBER Salute Speech service.",
   "main": "./lib/index.js",
   "files": [
@@ -42,6 +42,12 @@
     "url": "https://github.com/RaftDigiAI/sber-salute-speech-recognition/issues"
   },
   "homepage": "https://github.com/RaftDigiAI/sber-salute-speech-recognition#readme",
+  "dependencies": {
+    "axios": "^1.4.0",
+    "music-metadata": "^7.13.4",
+    "qs": "^6.11.2",
+    "uuid": "^9.0.0"
+  },
   "devDependencies": {
     "@ryansonshine/commitizen": "^4.2.8",
     "@ryansonshine/cz-conventional-changelog": "^3.3.4",
@@ -117,11 +123,5 @@
       "@semantic-release/npm",
       "@semantic-release/github"
     ]
-  },
-  "dependencies": {
-    "axios": "^1.4.0",
-    "music-metadata": "^7.13.4",
-    "qs": "^6.11.2",
-    "uuid": "^9.0.0"
   }
 }

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -2,3 +2,12 @@ export enum Scope {
   Personal = 'SALUTE_SPEECH_PERS',
   Corporate = 'SALUTE_SPEECH_CORP',
 }
+
+export enum AudioEncoding {
+  MP3 = 'MP3',
+  PCM_S16LE = 'PCM_S16LE',
+  FLAC = 'FLAC',
+  OPUS = 'OPUS',
+  ALAW = 'ALAW',
+  MULAW = 'MULAW',
+}

--- a/src/sberSaluteSpeechRecognitionService.ts
+++ b/src/sberSaluteSpeechRecognitionService.ts
@@ -11,7 +11,6 @@ import {
 } from './constants';
 import * as uuid from 'uuid';
 import {
-  SupportedAudioEncoding,
   SpeechToTextResult,
   SberSaluteToken,
   FileUploadResponse,
@@ -19,12 +18,12 @@ import {
   RecognitionResultResponse,
   RecognitionStatusResponse,
 } from './types';
-import { Scope } from './enums';
+import { Scope, AudioEncoding } from './enums';
 
 export interface ISberSaluteSpeechRecognitionService {
   speechToText(
     audioPath: string,
-    encoding: SupportedAudioEncoding
+    encoding: AudioEncoding
   ): Promise<SpeechToTextResult>;
 }
 
@@ -102,7 +101,7 @@ export class SberSaluteSpeechRecognitionService
   private async startRecognition(
     uploadedFile: FileUploadResponse,
     fileMetadata: IAudioMetadata,
-    encoding: SupportedAudioEncoding
+    encoding: AudioEncoding
   ): Promise<RecognitionResponse> {
     const data = JSON.stringify({
       options: {
@@ -177,7 +176,7 @@ export class SberSaluteSpeechRecognitionService
 
   async speechToText(
     audioPath: string,
-    encoding: SupportedAudioEncoding
+    encoding: AudioEncoding
   ): Promise<SpeechToTextResult> {
     const metadata = await parseFile(audioPath);
     const fileUploadResponse = await this.uploadFileForRecognition(audioPath);

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,11 +43,3 @@ export type SpeechToTextResult = {
   text: string;
   normalizedText: string;
 };
-
-export type SupportedAudioEncoding =
-  | 'MP3'
-  | 'PCM_S16LE'
-  | 'FLAC'
-  | 'OPUS'
-  | 'ALAW'
-  | 'MULAW';


### PR DESCRIPTION
Accept audio encoding as enum value

BREAKING CHANGE: Audio encoding is enum now

### Pull-Request Checklist

- [x] Code is up-to-date with the `main` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

